### PR TITLE
Add README setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment configuration for Miro Template Generator
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=public-anon-key
+# Optional: token used for creating boards in Miro
+VITE_MIRO_TOKEN=your-miro-token

--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# Miro Template Generator
+
+This project lets you generate Miro board templates using an AI backed by Supabase edge functions. It is built with React and Vite.
+
+## Prerequisites
+
+- Node.js 18 or newer
+- npm (comes with Node.js)
+
+## Installation
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+## Configuration
+
+Create a `.env` file in the project root. The following variables are used by the app:
+
+```bash
+VITE_SUPABASE_URL=<your-supabase-url>
+VITE_SUPABASE_ANON_KEY=<your-supabase-anon-key>
+# Optional: token used to create boards through the Miro API
+VITE_MIRO_TOKEN=<your-miro-token>
+```
+
+An `.env.example` file is provided as a reference.
+
+If you deploy the included Supabase Edge Function (`supabase/functions/claude-chat`), set the `CLAUDE_API_KEY` variable in your Supabase project with your Anthropic API key.
+
+## Running the development server
+
+Start the Vite dev server with:
+
+```bash
+npm run dev
+```
+
+This will serve the application on <http://localhost:5173> by default.
+
+## Building the project
+
+To create an optimized production build run:
+
+```bash
+npm run build
+```
+
+The output will be written to the `dist` folder.


### PR DESCRIPTION
## Summary
- document how to run the app and what environment variables are required
- provide `.env.example`

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm install` *(fails: unable to download packages due to no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_687572fa0e0c83338cd07df1fd27f372