### PR TITLE
Fix frame coordinates in miro API helpers

### DIFF
--- a/src/utils/miroApi.ts
+++ b/src/utils/miroApi.ts
@@ -11,10 +11,14 @@ interface MiroBoard {
 interface MiroFrame {
   id: string;
   title: string;
-  x: number;
-  y: number;
-  width: number;
-  height: number;
+  position: {
+    x: number;
+    y: number;
+  };
+  geometry: {
+    width: number;
+    height: number;
+  };
 }
 
 interface MiroStickyNote {
@@ -124,8 +128,8 @@ export const createBoardFromTemplate = async (token: string, template: Template)
           content: element,
         },
         position: {
-          x: createdFrame.x + 50,
-          y: createdFrame.y + elementY,
+          x: createdFrame.position.x + 50,
+          y: createdFrame.position.y + elementY,
         },
         style: {
           fillColor: "#ffe066", // Yellow sticky note


### PR DESCRIPTION
## Summary
- update `MiroFrame` definition to match the API response
- reference `createdFrame.position` when placing sticky notes

## Testing
- `npm run build` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687572e4e6648333a0f3dfde92c938b3